### PR TITLE
Address Lorenzo's comments

### DIFF
--- a/draft-link-v6ops-464xlaton.xml
+++ b/draft-link-v6ops-464xlaton.xml
@@ -124,7 +124,7 @@ Terminology
 <ul>
 <li>
 <t>
-IPv6-only network: a network which do not assign IPv4 addresses to hosts and provides connectivity to IPv4-only destinations via NAT64 (<xref target="RFC6146"/>).
+IPv6-only network: A network that does not assign IPv4 addresses to hosts and facilitates connectivity to IPv4-only destinations using NAT64 ((<xref target="RFC6146"/>). In this document, the term "IPv6-only network" specifically refers to networks that provide NAT64 as it's required by the 464XLAT architecture (<xref target="RFC6877"/>).
 </t>
 </li>
 <li>

--- a/draft-link-v6ops-464xlaton.xml
+++ b/draft-link-v6ops-464xlaton.xml
@@ -205,7 +205,7 @@ Despite the word "wireless" in the name, this architecure is applicable for wire
 In the latter case, the CLAT instance needs a single IPv6 and a single IPv4 address only.
 The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
 If the node runs multiple CLAT instances (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
-This means that it might not be possible to run more than 8 CLAT instances per node.
+This means that it is not possible to run more than 8 CLAT instances per node.
 The node MUST NOT send packets on wire from the local CLAT address.
 </t>
 <t>

--- a/draft-link-v6ops-464xlaton.xml
+++ b/draft-link-v6ops-464xlaton.xml
@@ -62,7 +62,7 @@
 
     <abstract>
  <t>
-464XLAT (<xref target="RFC6877"/>) defines an arcitecture for providing IPv4 connectivity across an IPv6-only network.
+464XLAT (<xref target="RFC6877"/>) defines an architecture for providing IPv4 connectivity across an IPv6-only network.
 The solution  contains two key elements: provider-side translator (PLAT) and customer-side translator (CLAT).
 This document provides recommendations on when a node shall enable or disable CLAT.
 </t>
@@ -121,9 +121,18 @@ This document complements <xref target="RFC6877"/> by  providing recommendations
 <name>
 Terminology
 </name>
+<ul>
+<li>
 <t>
-To be added
+IPv6-only network: a network which do not assign IPv4 addresses to hosts and provides connectivity to IPv4-only destinations via NAT64 (<xref target="RFC6146"/>).
 </t>
+</li>
+<li>
+<t>
+CLAT Node: a node (a host or a router) which performs CLAT functions by running one or multiple CLAT instances (e.g. one CLAT instance per interface).
+</t>
+</li>
+</ul>
 </section>
 <section anchor="multihomed">
 <name>Multiple Interfaces Considerations</name>
@@ -166,26 +175,72 @@ Therefore, the node SHOULD enable CLAT as soon as network support for PLAT is de
 CLAT Addresses Considerations
 </name>
 
+
+<section anchor="v4addr">
+<name>
+CLAT IPv4 Addresses
+</name>
+<t>
+There are two different models in 464xlat deployments:
+</t>
+<ul>
+<li>
+<t>
+A dedicated prefix model, which Section 4.1 of <xref target="RFC6877"/> calls "wireline network architecture".
+In that case, the node performing CLAT functions also extends the network downstream and provides network connectivity services to other connected systems.
+Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
+In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses.
+</t>
+</li>
+<li>
+<t>
+A single-address model, which section 4.2 of <xref target="RFC6877"/> calls "wireless network architecture".
+In that case, the CLAT instance provides an IPv4 address and the default route to the local node's network stack only.
+It should be noted that <xref target="RFC6877"/> implies that the second deployment scenario is limited to 3GPP cases, while currently it is also deployed in other types of networks, such as enterprise and public Wi-Fi networks, where hosts (as mobile phones, laptops and desktops) use CLAT to provide connectivity to IPv4-only local applications.
+Despite the word "wireless" in the name, this architecure is applicable for wired networks as well (e.g. desktops or servers using wired connections).
+</t>
+</li>
+</ul>
+<t>
+In the latter case, the CLAT instance needs a single IPv6 and a single IPv4 address only.
+The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
+If the node runs multiple CLAT instances (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
+This means that it might not be possible to run more than 8 CLAT instances per node.
+The node MUST NOT send packets on wire from the local CLAT address.
+</t>
+<t>
+The host SHOULD use 255.255.255.255 as a netmask for the CLAT address.
+That allows all 8 addresses from 192.0.0.0/29 to be used, if needed.
+</t>
+<t>
+It should be noted that 192.0.0.0/29 is shared between multiple IPv4 continuity solutions such as 464XLAT and DS-Lite (see <xref target="RFC7335"/>.
+For example, Section 10 of <xref target="RFC6333"/> reserves 192.0.0.1 for the Dual-Stack Lite default router.
+However, as per Section 4 of <xref target="RFC7335"/>, the host MUST NOT enable two active IPv4 continuity solutions simultaneously in a way that would cause a node to have overlapping 192.0.0.0/29 address space.
+Therefore, as long as the host is not using DS-Lite, it MAY use 192.0.0.1 as a CLAT address.
+</t>
+
+</section>
+
 <section anchor="v6addr">
 <name>
 CLAT IPv6 Addresses
 </name>
 <t>
-Section 6.3 of <xref target="RFC6877"/> recommends that the node acquires a dedicated /64 for its CLAT functions, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
+Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, to say the least.
-In most cases, the node uses a single IPv6 address as a source for all IPv4 traffic translated bt CLAT. 
+In most cases, the CLAT instance uses a single IPv6 address as a source for all IPv4 traffic translated bt CLAT. 
 </t>
 <t>
-The node SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
-This is required as when the node receives a packet from a NAT64 source, the node needs to differentiate between native IPv6 traffic and traffic which needs to be passed to CLAT.
+The CLAT instance SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+This is required as when the node receives a packet from a NAT64 source, the node needs to differentiate between native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example, an ICMPv6 Echo Reply packet from 64:ff9b::203.0.113.1 can be a response to either an IPv6 ping to 64:ff9b::203.0.113.1, or an IPv4 ping to 203.0.113.1, translated by CLAT.
-Using a dedicated IPv6 source address for all CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC6145"/>.
+Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC6145"/>.
 </t>
 <t>
-In accordance with Section 5.4 of <xref target="RFC4862"/>, the node MUST perform Duplicate Address Detection for its dedicated CLAT address.
+In accordance with Section 5.4 of <xref target="RFC4862"/>, the node MUST perform Duplicate Address Detection for each dedicated CLAT address.
 </t>
 <t>
-If the dedicated CLAT address is obtained via SLAAC, the node SHOULD ensure that the address is checksum-neutral for the given local IPv4 CLAT address and the NAT64 prefix (this means that the local IPv4 address needs to be assigned/known before the IPv6 one is configured).
+If the dedicated CLAT address is obtained via SLAAC, the CLAT instance SHOULD ensure that the address is checksum-neutral for the given local IPv4 CLAT address and the NAT64 prefix (this means that the local IPv4 address needs to be assigned/known before the IPv6 one is configured).
 Using a checksum-neutral CLAT address provides the following benefits:
 </t>
 <ul>
@@ -205,50 +260,6 @@ The node SHOULD generate a different interface id for the CLAT address when conn
 To achieve that, the node SHOULD generate a random checksum-neutral CLAT address every time.
 </t>
 </section>
-
-<section anchor="v4addr">
-<name>
-CLAT IPv4 Addresses
-</name>
-<t>
-There are two different cases of IPv4 usage in 464XLAT deployments:
-</t>
-<ul>
-<li>
-<t>
-Wireline network architecture, as defined in Section 4.1 of <xref target="RFC6877"/>. In that case, the node performing CLAT functions also extends the network downstream and provides network connectivity services to other connected systems.
-Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
-In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses.
-</t>
-</li>
-<li>
-<t>
-Wireless network architecture, as defined in Section 4.2 of <xref target="RFC6877"/>.
-In that case, the CLAT node provides an IPv4 address and the default route to the local node's network stack only.
-It should be noted that <xref target="RFC6877"/> implies that the second deployment scenario is limited to 3GPP cases, while currently it is also deployed in other types of networks, such as enterprise and public Wi-Fi networks, where hosts (as mobile phones, laptops and desktops) use CLAT to provide connectivity to IPv4-only local applications.
-Despite the word "wireless" in the name, this architecure is applicable for wired networks as well (e.g. desktops or servers using wired connections).
-</t>
-</li>
-</ul>
-<t>
-In the latter case, the CLAT node needs a single IPv4 address only. The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
-If the node runs multiple CLAT instances (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
-This means that it might not be possible to run more than 8 CLAT instances per node.
-The node MUST NOT send packets on wire from the local CLAT address.
-</t>
-<t>
-The host SHOULD use 255.255.255.255 as a netmask for the CLAT address.
-That allows all 8 addresses from 192.0.0.0/29 to be used, if needed.
-</t>
-<t>
-It should be noted that 192.0.0.0/29 is shared between multiple IPv4 continuity solutions such as 464XLAT and DS-Lite (see <xref target="RFC7335"/>.
-For example, Section 10 of <xref target="RFC6333"/> reserves 192.0.0.1 for the Dual-Stack Lite default router.
-However, as per Section 4 of <xref target="RFC7335"/>, the host MUST NOT enable two active IPv4 continuity solutions simultaneously in a way that would cause a node to have overlapping 192.0.0.0/29 address space.
-Therefore, as long as the host is not using DS-Lite, it MAY use 192.0.0.1 as a CLAT address.
-</t>
-
-</section>
-
 </section>
 <section anchor="disable">
 <name>Disabling CLAT</name>
@@ -408,6 +419,7 @@ This document does not introduce any privacy considerations.
         <name>Normative References</name>
         
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
+	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6146.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6333.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6877.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7050.xml"/>


### PR DESCRIPTION
- Define "IPv6-only network"
- Replace "CLAT node" with "CLAT instance" and add it to the terminology
- Swap sections 6.1 and 6.2