### PR TITLE
Allow permissive approaches to IPv4 versus CLAT usage preference

### DIFF
--- a/draft-link-v6ops-464xlaton.xml
+++ b/draft-link-v6ops-464xlaton.xml
@@ -153,7 +153,10 @@ Therefore the node SHOULD enable CLAT if it receives an Router Advertisement con
 </t>
 <t>
 If RAs received by the node do not contain a PREF64 option, the node MAY use other mechanisms to detect the PLAT presence and obtain the NAT64 prefix (such as <xref target="RFC7050"/>).
-In that case, the node SHOULD enable CLAT after discovering the NAT64 prefix, unless by that time the node has already obtained an IPv4 address.
+In that case, the node SHOULD enable CLAT after discovering the NAT64 prefix. The node MAY choose to use native IPv4 or not when it is available on a 
+dual-stack network after the NAT64 prefix is discovered. The trade-off is performance (using native IPv4) versus
+maximizing IPv6 use on the network (using CLAT even when IPv4 is available). The latter could be desirable for administrators who want to audit the
+devices still using IPv4 and force every node that is capable of CLAT to use it.
 </t>
 <t>
 The node MUST follow recommendations from Section 4 of <xref target="RFC7335"/> to avoid IPv4 address space conflicts.
@@ -161,11 +164,13 @@ The node MUST follow recommendations from Section 4 of <xref target="RFC7335"/> 
 <section anchor="ipv4detect">
 <name>Detecting IPv4 Presence</name>
 <t>
-From a performance perspective, native IPv4 connectivity is preferrable over 464XLAT, so CLAT SHOULD NOT be enabled if the node has IPv4 connectivity over the given interface.
-However, SLAAC might complete faster than DHCPv4. 
-The node SHOULD NOT wait for an explicit (DHCPv4 Option 108, <xref target="RFC8925"/>) or an implicit (DHCPv4 timeouts) indication that native IPv4 connectivity is not available.
+From a performance perspective, native IPv4 connectivity is preferrable over 464XLAT, so nodes that are configured to prefer native IPv4 over using CLAT
+will need to account for cases where SLAAC might complete faster than DHCPv4. 
+The node SHOULD NOT wait for an explicit (DHCPv4 Option 108, <xref target="RFC8925"/>) or an implicit (DHCPv4 timeouts) indication that native IPv4
+connectivity is not available once a prefix is discovered by the node's supported NAT64 prefix discoveyr mechanisms, even if the node prefers native IPv4 to CLAT.
 Such delay would be impactful for IPv4-only applications, as such applications cannot benefit from 464XLAT until CLAT is operational.
-Therefore, the node SHOULD enable CLAT as soon as network support for PLAT is detected while IPv4 connectivity is not yet detected. Clients SHOULD then disable CLAT if native IPv4 connectivity is established whether or not PLAT support from the network remains available.
+Therefore, independent of preference for native IPv4 or CLAT, the node SHOULD enable CLAT as soon as network support for PLAT is detected while
+IPv4 connectivity is not yet detected. Clients MAY then disable CLAT if native IPv4 connectivity is established whether or not PLAT support from the network remains available.
 </t>
 </section>
 </section>


### PR DESCRIPTION
Modified the normative requirements and explanations to enables nodes to either use IPv4 directly or CLAT even when IPv4 is available, while still requiring use of CLAT once the prefix is discovered.

Addresses #7 