### PR TITLE
Addressing IETF121 Comments

### DIFF
--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -307,21 +307,9 @@ That improves the chances of the protocol working via CLAT even if CLAT is not a
 </ul>
 
 <t>
-The node SHOULD treat SLAAC-generated CLAT addresses as temporary addresses (<xref target="RFC8981"/>). In particular:
+To protect user privacy and prevent user tracking through CLAT addresses, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks, even if the NAT64 prefix and the local IPv4 CLAT address do not change. 
+In particular, the node SHOULD generate a random CLAT address every time the network attachement changes to another network.
 </t>
-<ul>
-<li>
-<t>
-The node SHOULD generate new CLAT addresses over time, as described in Sections 3.4 and 3.6 of <xref target="RFC8981"/>.
-</t>
-</li>
-<li>
-<t>
-The node SHOULD generate a different interface id for the CLAT address when connecting to different networks, even if the NAT64 prefix and the local IPv4 CLAT address do not change. 
-To achieve that, the node SHOULD generate a random checksum-neutral CLAT address every time the network attachement changes to another network.
-</t>
-</li>
-</ul>
 
 <section anchor="mhoming">
 <name>CLAT and Multiple Prefixes per Interface</name>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -288,8 +288,21 @@ Using a dedicated IPv6 source address for CLAT traffic allows the node to make t
 In a dedicated prefix model, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </t>
 <t>
-In accordance with Section 5.4 of <xref target="RFC4862"/>, the node MUST perform Duplicate Address Detection for each dedicated CLAT address.
+The node MUST comply with  <xref target="RFC4861"/> and  <xref target="RFC4862"/> for the node CLAT addresses. In particular:
 </t>
+<ul>
+<li>
+<t>
+Performing Duplicate Address Detection for each dedicated CLAT address (Section 5.4 of <xref target="RFC4862"/>);
+</t>
+</li>
+<li>
+<t> Process received Neighbor Solicitations sent to the solicited-node multicast address (<xref target="RFC4861"/>) for the node CLAT addresses.</t>
+</li>
+<li>
+<t>Sending Gratuitous Neighbor Advertisements (<xref target="RFC9131"/>) for the CLAT addresses.</t>
+</li>
+</ul>
 <t>
 If the dedicated CLAT address is obtained via Stateless Address Autoconfiguration (SLAAC, <xref target="RFC4862"/>), the CLAT instance SHOULD ensure that the address is checksum-neutral for the given local IPv4 CLAT address and the NAT64 prefix (this means that the local IPv4 address needs to be assigned/known before the IPv6 address is configured).
 Using a checksum-neutral CLAT address provides the following benefits:
@@ -523,6 +536,8 @@ To summarize, this document does not introduce any new privacy considerations.
         
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3927.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4861.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4862.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6146.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6147.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6333.xml"/>
@@ -538,6 +553,7 @@ To summarize, this document does not introduce any new privacy considerations.
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8585.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8925.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8981.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9131.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
         
       </references>
@@ -545,7 +561,6 @@ To summarize, this document does not introduce any new privacy considerations.
       <references>
 	      <name>Informative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.1918.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4862.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6145.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7225.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8900.xml"/>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -350,7 +350,7 @@ This document does not aim to define CLAT behavior for every possible multi-rout
 
 
 <t>
-A node discovering multiple routers on the same interface advertizing the <em>same PIOs and NAT64 prefix</em>, SHOULD only create one CLAT instance using one of the PIOs to form a CLAT address. 
+A node discovering multiple routers on the same interface advertising the <em>same PIOs and NAT64 prefix</em>, SHOULD only create one CLAT instance using one of the PIOs to form a CLAT address. 
 When multiple PIOs are advertized, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>) prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
 </t>
 <t>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -353,7 +353,9 @@ MTU Considerations
 <t>
 The IPv4 header is 20 bytes long (or longer if IP options are present), while the IPv6 header is 40 bytes.
 This means that when CLAT translates an IPv4 packet to IPv6, it usually adds 20 bytes to the packet size.
-To minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-address mode SHOULD present IPv4-only applications with an IPv4 MTU which is 20 bytes smaller than the IPv6 MTU of the interface the instance is running on.
+However, when CLAT transates a fragmented IPv4 packet, then Fragment Header needs to be added to the resulting IPv6 packet (Section 4.1 of <xref target="RFC7915"/>).
+The length of IPv6 Fragment Extension header is 8 bytes (Section 4.5 of <xref target="RFC8200"/>).
+Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-address mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
 </t>
 </section>
 
@@ -539,6 +541,8 @@ To summarize, this document does not introduce any new privacy considerations.
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6877.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7050.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7335.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7915.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8200.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8880.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8028.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8174.xml"/>
@@ -707,7 +711,7 @@ To summarize, this document does not introduce any new privacy considerations.
     <section anchor="Acknowledgements" numbered="false">
       <name>Acknowledgements</name>
 <t>
-Thanks to Ondrej Caletka, Stuart Cheshire, Lorenzo Colitti, Jeremy Duncan, Jason Healy, Ed Horley, KAWASHIMA Masanobu, Ted Lemon, George Michaelson, Jordi Palet, Dieter Siegmund for the discussions, the input, and all contribution.
+Thanks to Ondrej Caletka, Stuart Cheshire, Lorenzo Colitti, Jeremy Duncan, Jason Healy, Ed Horley, KAWASHIMA Masanobu, Ted Lemon, George Michaelson, Jordi Palet, Dieter Siegmund, Eric Vyncke for the discussions, the input, and all contribution.
 </t>
     </section>
     

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -140,6 +140,11 @@ IPv6-only network: A network that does not assign IPv4 addresses to hosts and fa
 Native IPv4 (such as in 'native IPv4 connectivity' or 'native IPv4 default gateway'): IPv4 connectivity or default gateway provided by the network without using any form of IPv4-as-a-service or translation mechanisms (such as 464XLAT).
 </t>
 </li>
+<li>
+<t>
+ULA: Unique Local Addresses, <xref target="RFC4193"/>.
+</t>
+</li>
 </ul>
 
 <t>
@@ -351,15 +356,38 @@ This document does not aim to define CLAT behavior for every possible multi-rout
 
 <t>
 A node discovering multiple routers on the same interface advertising the <em>same PIOs and NAT64 prefix</em>, SHOULD only create one CLAT instance using one of the PIOs to form a CLAT address. 
-When multiple PIOs are advertized, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>) prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
 </t>
 <t>
 A node discovering multiple routers on the same interface signalling the <em>different PIOs and NAT64 prefixes</em>, MAY create one CLAT instance for each tuple of PIOs and NAT64 prefix, or only a single CLAT instance using the NAT64 prefix discovered through the selected IPv6 default router and the address formed from a PIO advertized by that router.  
 </t>
 
 <t>
-In both cases described above, if the node creates a single CLAT instance only and a choice needs to be made between multiple PIOs, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>)  prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
+When a node creates a single CLAT instance and must choose between multiple PIOs, the node SHOULD select a single PIO using the same algorithm as for choosing the source address for a destination within the selected NAT64 prefix (<xref target="RFC6724"/>, updated by <xref target="I-D.ietf-6man-rfc6724-update"/>).</t>
+<t>Discussion: This approach, leveraging the default source address selection algorithm (Section 5 of <xref target="RFC6724"/>), typically results in the policy table (rule 6) and longest prefix match (rule 8) being used for prefix selection.
+This ensures CLAT address selection aligns with default source address selection for native IPv6 flows, offering the following advantages:
 </t>
+<ul>
+<li>
+<t>
+When using the well-known NAT64 prefix (64:ff9b::/96), non-ULA prefixes are preferred over ULA prefixes by default. This is beneficial as ULA source packets may not reach PLAT devices.
+</t>
+</li>
+<li>
+<t>
+For network-specific NAT64 prefixes within the known-local ULA range (<xref target="I-D.ietf-6man-rfc6724-update"/>), the ULA prefix is preferred. This can be advantageous in home and enterprise environments where administrators intend to perform NAT64 for specific source prefixes only.
+</t>
+</li>
+<li>
+<t>
+For network-specific NAT64 prefixes within the operator's global non-ULA range, the longest prefix match selects the PIO, ensuring CLAT uses the operator's source address for traffic to the operator's PLAT in multi-prefix environments.
+</t>
+</li>
+<li>
+<t>
+In managed environments, operators can customize CLAT behavior by modifying the policy table if the default prefix selection is unsuitable.
+</t>
+</li>
+</ul>
 
 <t>
 Creating a single CLAT instance significantly simplifies the CLAT state machine.
@@ -614,6 +642,7 @@ To summarize, this document does not introduce any new privacy considerations.
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6146.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6147.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6333.xml"/>
+	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6724.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6877.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7050.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7335.xml"/>
@@ -628,6 +657,7 @@ To summarize, this document does not introduce any new privacy considerations.
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8981.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9131.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9686.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-6man-rfc6724-update.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
         
       </references>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -288,7 +288,7 @@ Using a dedicated IPv6 source address for CLAT traffic allows the node to make t
 In a dedicated prefix model, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </t>
 <t>
-The node MUST comply with  <xref target="RFC4861"/> and  <xref target="RFC4862"/> for the node CLAT addresses. In particular:
+The node MUST treat the CLAT addresses as any other addresses and comply with <xref target="RFC4861"/> and <xref target="RFC4862"/>. In particular:
 </t>
 <ul>
 <li>
@@ -297,10 +297,13 @@ Performing Duplicate Address Detection for each dedicated CLAT address (Section 
 </t>
 </li>
 <li>
-<t> Process received Neighbor Solicitations sent to the solicited-node multicast address (<xref target="RFC4861"/>) for the node CLAT addresses.</t>
+<t> Processing received Neighbor Solicitations sent to the solicited-node multicast address (<xref target="RFC4861"/>) for the node CLAT addresses.</t>
 </li>
 <li>
 <t>Sending Gratuitous Neighbor Advertisements (<xref target="RFC9131"/>) for the CLAT addresses.</t>
+</li>
+<li>
+Registering the CLAT addresses using DHCPv6 (<xref target="RFC9686"/>), if the network supports the registration.
 </li>
 </ul>
 <t>
@@ -554,6 +557,7 @@ To summarize, this document does not introduce any new privacy considerations.
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8925.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8981.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9131.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.9686.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
         
       </references>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -358,7 +358,7 @@ A node discovering multiple routers on the same interface signalling the <em>dif
 </t>
 
 <t>
-In both cases described above, if the node create a single CLAT instance only and a choice needs to be made between multiple PIOs, the mode SHOULD prefer non-ULA (<xref target="RFC4193"/>)  prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
+In both cases described above, if the node creates a single CLAT instance only and a choice needs to be made between multiple PIOs, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>)  prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
 </t>
 
 <t>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -16,7 +16,7 @@
 <rfc
   xmlns:xi="http://www.w3.org/2001/XInclude"
   category="info"
-  docName="draft-ietf-v6ops-claton-02"
+  docName="draft-ietf-v6ops-claton-03"
   ipr="trust200902"
   obsoletes=""
   updates="8585"
@@ -25,7 +25,7 @@
   version="3">
   <front>
 <title abbrev="claton">464XLAT Customer-side Translator (CLAT): Node Recommendations</title>
-    <seriesInfo name="Internet-Draft" value="draft-ietf-v6ops-claton-02"/>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-v6ops-claton-03"/>
     <author fullname="Jen Linkova" initials="J" surname="Linkova">
       <organization>Google</organization>
       <address>
@@ -47,7 +47,7 @@
         <email>tojens@microsoft.com</email>
       </address>
     </author>
-    <date year="2024"/>
+    <date year="2025"/>
 <area>Ops</area>
     <workgroup>IPv6 operations</workgroup>
     <keyword>ipv6</keyword>
@@ -607,7 +607,6 @@ To summarize, this document does not introduce any new privacy considerations.
         <name>Normative References</name>
         
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3927.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4193.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4861.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4862.xml"/>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -373,13 +373,14 @@ Link Renumbering
 </name>
 
 <t>
-As discussed above, it is usually sifficient to create a single CLAT instance per interface, utilizing a single PIO, even if the link has multiple subnets assigned.
-However there is one particular scenario, when the prefix selection might have a significant impact on user experience: link renumbering.
+As discussed above, a single CLAT instance per interface, using a single PIO, is typically sufficient, even if the link has multiple assigned subnets.
+However, PIO selection can significantly impact user experience during link renumbering. 
 </t>
 <t>
-<xref target="RFC8978"/> discusses various examples of so-called flash renumbering, when the IPv6 prefix assigned to the link changes, without any explicit notification to the hosts. <xref target="I-D.ietf-6man-slaac-renum"/> and <xref target="I-D.link-6man-gulla"/> discuss possible approaches to minimize the flash renumbering impact.
-In a nutshell all those methods expect the host which has addresses from both old and new prefixes assigned, to stop using the old prefix and start using addresses from the new prefix. 
-For the node running CLAT instances it means that the instance(s) using addresses from the old prefix should be disabled, and an instance using an address from the new prefix should be created.
+<xref target="RFC8978"/> discusses various examples of "flash renumbering," where the IPv6 prefix assigned to the link changes without explicit host notification. 
+
+<xref target="I-D.ietf-6man-slaac-renum"/> and <xref target="I-D.link-6man-gulla"/> discuss methods to mitigate the impact of flash renumbering.  These methods generally rely on hosts with addresses from both old and new prefixes ceasing use of the old prefix and adopting the new prefix.
+For nodes running CLAT instances, this requires disabling instances using addresses from the old prefix and creating an instance using an address from the new prefix.
 </t>
 
 <t>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -508,7 +508,7 @@ This document mitigates this risk by requiring endpoints to disable CLAT when th
     <section anchor="privacy">
       <name>Privacy Considerations</name>
       <t>
-If the instance utilizes the same CLAT address for an extensive period of time or, much worse, uses the same CLAT address when connecting to different networks, eavesdroppers and information collectors can correlate various network activity to the same node. To mitigate that risk and make address-based network-activity correlation more difficult, each CLAT instance's source IPv6 address SHOULD be rotated the same way as temporary IPv6 addresses (see <xref target="v6addr"/>).
+If the instance utilizes the same CLAT address for an extensive period of time or, much worse, uses the same CLAT address when connecting to different networks, eavesdroppers and information collectors can correlate various network activity to the same node. To mitigate that risk and make address-based network-activity correlation more difficult, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks (see <xref target="v6addr"/>).
 </t>
 <t>
 It should be noted that the node's CLAT IPv6 address is only used (and visible to observers) when the traffic is carried from the CLAT node to the PLAT device.

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -327,28 +327,97 @@ To protect user privacy and prevent user tracking through CLAT addresses, the no
 In particular, the node SHOULD generate a random CLAT address every time the network attachement changes to another network.
 </t>
 
+</section>
+</section>
+
 <section anchor="mhoming">
 <name>CLAT and Multiple Prefixes per Interface</name>
 <t>
-The CLAT instance SHOULD obtain a dedicated IPv6 address (or addresses, if a dedicated prefix model is used) from each global prefix used to configure IPv6 addresses on the given interface. When selecting an address to be used as a source address for the translated packet, the following rules are applied:
+IPv6 multihoming, particularly when multiple routers on the same link advertise different prefixes PIOs, presents a complex and not yet fully resolved challenge.
+</t>
+<t>
+When routers on a given link are managed independently (e.g., by different ISPs), the resulting set of configuration parameters received by a host can be difficult to utilize without creating a complex and fragile state machine. 
+For example, if router_A advertises a PIO with prefix_A and PREF64_A, while router_B advertises a PIO with prefix_B and a PREF64_B, it is crucial that the CLAT bundles the information received from each router.
+A CLAT instance must use PREF64_A and generate a CLAT address from prefix_A, sending translated packets to router_A.  Alternatively, it must use PREF64_B, generate an address from prefix_B, and send translated packets to router_B. 
+Mixing configuration information from different routers (e.g., generating a CLAT address from prefix_A but using PREF64_B for translation) can lead to packet loss.
+For example, if packets with source addresses from prefix_A are sent to router_B, that router (or the uplink network) might drop the packets according to BCP 38 (<xref target="RFC2827"/>).
+Similarly, if the CLAT instance uses PREF64_A, advertised by router_A, but those packets are sent to router_B, that router might not be configured to translate packets for that prefix.
+</t>
+
+<t>
+This document does not aim to define CLAT behavior for every possible multi-router/multi-prefix scenario. Instead, this section provides recommendations for common scenarios, leaving numerous corner cases out of scope.
+</t>
+
+
+<t>
+A node discovering multiple routers on the same interface advertizing the <em>same PIOs and NAT64 prefix</em>, SHOULD only create one CLAT instance using one of the PIOs to form a CLAT address. 
+When multiple PIOs are advertized, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>) prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
+</t>
+<t>
+A node discovering multiple routers on the same interface signalling the <em>different PIOs and NAT64 prefixes</em>, MAY create one CLAT instance for each tuple of PIOs and NAT64 prefix, or only a singe CLAT instance using the NAT64 prefix discovered through the selected IPv6 default router and the address formed from a PIO advertized by that router.  
+</t>
+
+<t>
+In both cases described above, if the node create a single CLAT instance only and a choice needs to be made between multiple PIOs, the mode SHOULD prefer non-ULA (<xref target="RFC4193"/>)  prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
+</t>
+
+<t>
+Creating a single CLAT instance significantly simplifies the CLAT state machine.
+However, this approach may concentrate all traffic from that instance onto the same first-hop router and NAT64 device in some multihomed topologies.
+As traffic shifts from CLAT to native IPv6, this drawback becomes less significant and does not justify the added complexity of multiple instances.
+</t>
+
+<section anchor="renumb">
+<name>
+Link Renumbering
+</name>
+
+<t>
+As discussed above, it is usually sifficient to create a single CLAT instance per interface, utilizing a single PIO, even if the link has multiple subnets assigned.
+However there is one particular scenario, when the prefix selection might have a significant impact on user experience: link renumbering.
+</t>
+<t>
+<xref target="RFC8978"/> discusses various examples of so-called flash renumbering, when the IPv6 prefix assigned to the link changes, without any explicit notification to the hosts. <xref target="I-D.ietf-6man-slaac-renum"/> and <xref target="I-D.link-6man-gulla"/> discuss possible approaches to minimize the flash renumbering impact.
+In a nutshell all those methods expect the host which has addresses from both old and new prefixes assigned, to stop using the old prefix and start using addresses from the new prefix. 
+For the node running CLAT instances it means that the instance(s) using addresses from the old prefix should be disabled, and an instance using an address from the new prefix should be created.
+</t>
+
+<t>
+The CLAT node SHOULD use at least the following signals to detect link renumbering events:
 </t>
 <ul>
 <li>
 <t>
-All packets with the same IPv4 5-tuple MUST be translated to the same IPv6 address, as long as that address is valid (<xref target="RFC4862"/>) and assigned to the interface. 
+A prefix used to form the CLAT address becomes deperecated or invalid (<xref target="RFC4862"/>).
 </t>
 </li>
 <li>
 <t>
-When translation for a new IPv4 5-tuple is performed by the CLAT instance, the instance SHOULD comply with requirements defined in Section 3 of <xref target="RFC8028"/>, in particular Sections 3.2 and 3.3 of <xref target="RFC8028"/>. This is needed to ensure that the CLAT is operational and selects the source IPv6 correctly in multihomed environments or if the link subnet has been changed (renumbered).
+The router (or routers) advertizing the PIO used to form the CLAT address</t>
+<ul>
+<li>
+<t> has changed it state from being reachable or probably reachable to being unknown or suspect (i.e., it's neighbor cache entry moved to the INCOMPLETE state or ceased to exist, see Section 6.3.6 of <xref target="RFC4861"/>).</t>
+</li>
+<li>
+<t>
+ceased to be a router (see Section 7.3.3 of  <xref target="RFC4861"/>).
 </t>
 </li>
 </ul>
+</li>
+</ul>
+
+<t>
+Upon receiving a signal indicating a possible renumbering event, the node SHOULD disable the CLAT instance(s) affected by the renumbering, and create new instance(s).
+In case of implicit signals (provided by the Neighbor Unreachability Detection, <xref target="RFC4861"/>, rather than by a Router Advertisement deprecating or invalidating a prefix), the node MAY send Router Solicitations to obtain the most up-to-date network configuration information.
+When sending Router Solicitations the node MUST follow recommendations specified in Section 6.3.7 of  <xref target="RFC4861"/>.
+The node MAY react to a potential renumebring event in a "make-before-break" manner, when old instances are still running until all required information to enable new ones becomes available.
+</t>
+</section>
+
 
 </section>
 
-</section>
-</section>
 
 <section>
 <name>
@@ -539,6 +608,7 @@ To summarize, this document does not introduce any new privacy considerations.
         
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2119.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.3927.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4193.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4861.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.4862.xml"/>
 	<xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6146.xml"/>
@@ -565,10 +635,14 @@ To summarize, this document does not introduce any new privacy considerations.
       <references>
 	      <name>Informative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.1918.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2827.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6145.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7225.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8900.xml"/>
+        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8978.xml"/>
         <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-pquip-pqc-engineers.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-6man-slaac-renum.xml"/>
+        <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.link-6man-gulla.xml"/>
 
       </references>
     </references>
@@ -718,7 +792,7 @@ To summarize, this document does not introduce any new privacy considerations.
     <section anchor="Acknowledgements" numbered="false">
       <name>Acknowledgements</name>
 <t>
-Thanks to Ondrej Caletka, Stuart Cheshire, Lorenzo Colitti, Jeremy Duncan, Jason Healy, Ed Horley, KAWASHIMA Masanobu, Ted Lemon, George Michaelson, Jordi Palet, Dieter Siegmund, Eric Vyncke for the discussions, the input, and all contribution.
+Thanks to Ondrej Caletka, Stuart Cheshire, Lorenzo Colitti, Jeremy Duncan, Jason Healy, Ed Horley, KAWASHIMA Masanobu, Ted Lemon, George Michaelson, Jordi Palet, Dieter Siegmund, Philipp S. Tiesel, Eric Vyncke for the discussions, the input, and all contribution.
 </t>
     </section>
     

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -354,7 +354,7 @@ A node discovering multiple routers on the same interface advertising the <em>sa
 When multiple PIOs are advertized, the node SHOULD prefer non-ULA (<xref target="RFC4193"/>) prefixes to ULA prefixes (as packets from ULA sources might not reach PLAT devices).
 </t>
 <t>
-A node discovering multiple routers on the same interface signalling the <em>different PIOs and NAT64 prefixes</em>, MAY create one CLAT instance for each tuple of PIOs and NAT64 prefix, or only a singe CLAT instance using the NAT64 prefix discovered through the selected IPv6 default router and the address formed from a PIO advertized by that router.  
+A node discovering multiple routers on the same interface signalling the <em>different PIOs and NAT64 prefixes</em>, MAY create one CLAT instance for each tuple of PIOs and NAT64 prefix, or only a single CLAT instance using the NAT64 prefix discovered through the selected IPv6 default router and the address formed from a PIO advertized by that router.  
 </t>
 
 <t>


### PR DESCRIPTION
- Reworking multi-homing/multi-prefix text to simplify the CLAT node behavior (declaring many corner cases out of scope) - also incorporating [Philipp](https://github.com/philsbln)'s text from another pull request;
 - Just one instance per link is OK but the node MAY choose to run mutiple.
- Adding a section for detecting renumbering
- Adding more text about the CLAT address being 'a normal' IPv6 address, so the node must do DAD, respond to NSes etc
- Removing the requirement to rotate the CLAT address (and updating the Privacy section accordingly)
- Fixing the MTU