### PR TITLE
Replace 6145 with 7915

### DIFF
--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -287,7 +287,7 @@ Even in a dedicated prefix model, the CLAT instance can first perform stateful N
 The CLAT instance SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is required as when the node receives a packet from a NAT64 source, the node needs to differentiate between native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example, an ICMPv6 Echo Reply packet from 64:ff9b::203.0.113.1 can be a response to either an IPv6 ping to 64:ff9b::203.0.113.1, or an IPv4 ping to 203.0.113.1, translated by CLAT.
-Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC6145"/>.
+Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC7915"/>.
 </t>
 <t>
 In a dedicated prefix model, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
@@ -666,7 +666,6 @@ To summarize, this document does not introduce any new privacy considerations.
 	      <name>Informative References</name>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.1918.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.2827.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.6145.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.7225.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8900.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8978.xml"/>


### PR DESCRIPTION
7915 obsoletes 6145, so updating the references ot not depend on an obsoleted RFC.