### PR TITLE
Tore's and Phillip's comments

### DIFF
--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -290,8 +290,10 @@ For example, an ICMPv6 Echo Reply packet from 64:ff9b::203.0.113.1 can be a resp
 Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC6145"/>.
 </t>
 <t>
-In a dedicated prefix model, the instance MAY attempt to obtain a /64 prefix.
-If the instance chooses not to obtain a dedicated prefix or if the prefix is not available, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
+<xref target="RFC6877"/> suggests that the CLAT instance a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
+This document updates <xref target="RFC6877"/> recommendations.
+More specifically, obtaining a /64 just for translating is NOT RECOMMENDED even in a dedicated prefix model.
+However, an instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </t>
 <t>
 The node MUST treat the CLAT addresses as any other address and comply with <xref target="RFC4861"/> and <xref target="RFC4862"/>. In particular:

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -167,7 +167,7 @@ The metrics of IPv4 routes SHOULD be consistent with the metrics of IPv6 default
 
 <t>
 For performance and security reasons CLAT MUST NOT be enabled if the node has IPv4 native connectivity over the given interface.
-Therefore recommendations provided in this section are only applicable to an IPv6-only interfaces of a given node (the node has no native IPv4 default route pointing to that interface).
+Therefore recommendations provided in this section are only applicable to the IPv6-only interfaces of a given node (the node has no native IPv4 default route pointing to that interface).
 </t>
 
 <t>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -19,7 +19,7 @@
   docName="draft-ietf-v6ops-claton-04"
   ipr="trust200902"
   obsoletes=""
-  updates="8585"
+  updates="6877, 8585"
   submissionType="IETF"
   xml:lang="en"
   version="3">
@@ -284,13 +284,14 @@ In particular, in a single address model (see <xref target="v4addr"/>) the CLAT 
 Even in a dedicated prefix model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
 </t>
 <t>
-The CLAT instance SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+In a single-address model, the CLAT instance SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is required as when the node receives a packet from a NAT64 source, the node needs to differentiate between native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example, an ICMPv6 Echo Reply packet from 64:ff9b::203.0.113.1 can be a response to either an IPv6 ping to 64:ff9b::203.0.113.1, or an IPv4 ping to 203.0.113.1, translated by CLAT.
 Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state and operate in the stateless mode (see Section 1.3 of <xref target="RFC6145"/>.
 </t>
 <t>
-In a dedicated prefix model, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
+In a dedicated prefix model, the instance MAY attempt to obtain a /64 prefix.
+If the instance chooses not to obtain a dedicated prefix or if the prefix is not available, the instance MAY obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </t>
 <t>
 The node MUST treat the CLAT addresses as any other address and comply with <xref target="RFC4861"/> and <xref target="RFC4862"/>. In particular:

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -16,7 +16,7 @@
 <rfc
   xmlns:xi="http://www.w3.org/2001/XInclude"
   category="info"
-  docName="draft-ietf-v6ops-claton-03"
+  docName="draft-ietf-v6ops-claton-04"
   ipr="trust200902"
   obsoletes=""
   updates="8585"
@@ -25,7 +25,7 @@
   version="3">
   <front>
 <title abbrev="claton">464XLAT Customer-side Translator (CLAT): Node Recommendations</title>
-    <seriesInfo name="Internet-Draft" value="draft-ietf-v6ops-claton-03"/>
+    <seriesInfo name="Internet-Draft" value="draft-ietf-v6ops-claton-04"/>
     <author fullname="Jen Linkova" initials="J" surname="Linkova">
       <organization>Google</organization>
       <address>
@@ -167,7 +167,7 @@ The metrics of IPv4 routes SHOULD be consistent with the metrics of IPv6 default
 
 <t>
 For performance and security reasons CLAT MUST NOT be enabled if the node has IPv4 native connectivity over the given interface.
-Therefore recommendations provided in this section are only applicable to an IPv6-only node (a node which does not have a native IPv4 default route configured).
+Therefore recommendations provided in this section are only applicable to an IPv6-only interfaces of a given node (the node has no native IPv4 default route pointing to that interface).
 </t>
 
 <t>


### PR DESCRIPTION
- clarify "dedicated /64" vs "dedicated IPv6 address" cases
- clarify that recommendations in this draft are for **an IPv6-only interface**, not an IPv6-only **node** (as the node might be multihomed to IPv4-enabled and IPv6-only networks)