### PR TITLE
Dedicated ipv6 prefix

### DIFF
--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -137,11 +137,6 @@ CLAT Node: a node (a host or a router) which performs CLAT functions by running 
 </li>
 <li>
 <t>
-Dedicated prefix model: a scenario when the node performing CLAT functions also extends the IPv4 network connectivity downstream, to other connected systems. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireline network architecture", this scenario is also applicable for wireless or 3GPP routers. Therefore the term "wireline" is no longer accurate and not used in this document.
-</t>
-</li>
-<li>
-<t>
 IPv4-only application: An application which requires the presence of an IPv4 address and/or IPv4 default route to operate. Examples include but are not limited to applications using IPv4 literals or opening IPv4-only sockets. 
 </t>
 </li>
@@ -153,11 +148,6 @@ IPv6-only network: A network that does not assign IPv4 addresses to hosts and fa
 <li>
 <t>
 Native IPv4 (such as in 'native IPv4 connectivity' or 'native IPv4 default gateway'): IPv4 connectivity or default gateway provided by the network without using any form of IPv4-as-a-service or translation mechanisms (such as 464XLAT).
-</t>
-</li>
-<li>
-<t>
-Single-address model: a scenario when the node performing CLAT functions provides an IPv4 address and the default route to the local node's network stack only. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireless network architecture", this scenario is applicable for wired networks as well (e.g. desktops or servers using wired connections). Therefore the term "wireless" is no longer accurate and not used in this document.
 </t>
 </li>
 <li>
@@ -244,29 +234,19 @@ CLAT Addresses Considerations
 CLAT IPv4 Addresses
 </name>
 <t>
-There are two different 464XLAT deployments models:
-</t>
-<ul>
-<li>
-<t>
-A dedicated prefix model (<xref target="RFC6877"/> uses the term "wireline network architecture").
-In that case, the node performing CLAT functions also extends the network downstream and provides network connectivity services to other connected systems.
+A CLAT instance provides an IPv4 address and the default route to the local node's network stack.
+However, the node can also extend the network downstream and provides network connectivity services to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
-In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses.
+ In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses. 
+The CLAT instance can either translate all other addresses statelessly to a dedicated prefix, or perform a stateful NAT44 between those addresses and a dedicated CLAT IPv4 address, which is stateless translated to a single dedicated IPv4 address.
 </t>
-</li>
-<li>
 <t>
-A single-address model (<xref target="RFC6877"/> uses the term "wireless network architecture").
-In that case, the CLAT instance provides an IPv4 address and the default route to the local node's network stack only.
-When <xref target="RFC6877"/> was published, this deployment scenario was limited to 3GPP cases. Today, it is also deployed in other types of networks, such as enterprise networks and Wi-Fi hotspots, where hosts (as mobile phones, laptops and desktops) use CLAT to provide connectivity to IPv4-only local applications.
+This section only applies to that single dedicated IPv4 address, which CLAT instance uses for providing network connectivity to local appications and (in case of extending network connectivity downstream) for stateful NAT44.
 </t>
-</li>
-</ul>
 <t>
-In the single-address model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
+The CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
 The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
-If the node runs multiple CLAT instances in the single-address model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
+If the node runs multiple CLAT instances (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
 This approach limits the number of CLAT instances per node to 8, which seems to be more that sufficient at the time of writing. 
 If in the future some deployment scenarios require more that 8 CLAT instances per node, a new larger IPv4 range will be requested from IANA.
 </t>
@@ -296,46 +276,30 @@ CLAT IPv6 Addresses
 Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, especially in environments like enterprise networks, Wi-Fi hotspots, etc. 
 Quite often the CLAT instance uses a single IPv6 address as a source for all IPv4 traffic translated by CLAT. 
-In particular, in a single address model (see <xref target="v4addr"/>) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
+In particular, if the CLAT only provides the IPv4 connectivity to applications local to the node (or if the node can perform stateful NAT44) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
 For instance, a home network that gets a /60 from its ISP can only connect up to 15 CLAT-enabled devices before it runs out of available prefixes.
-Even in a dedicated prefix model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
+Even if the node extends IPv4 connectivity downstream, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses used by downstream devices to a single IPv4 address, and then perform stateless CLAT. 
 </t>
 <t>
-This document updates <xref target="RFC6877"/> by removing the requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
+This document updates <xref target="RFC6877"/> by relaxing the requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
 The following recommendations are made instead:
 </t>
 <ul>
 <li>
 <t>
-In a single-address model, the CLAT instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
+If the node is extending IPv4 connectivity downstream and is not performing stateful NAT44 (so it needs to translate downstream IPv4 addresses to IPv6 statelessly), the node 
+SHOULD obtain a dedicated /64 prefix (e.g. via DHCPv6-PD).
 </t>
 </li>
 <li>
 <t>
-In a dedicated prefix model, the CLAT instance MAY do one of the following:
+If the CLAT instance only uses a single IPv4 address (including scenarios where the node is performing stateful NAT44 to that address), the instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
 </t>
-<ul>
-<li>
-<t>
-Perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, then perform stateless CLAT.
-</t>
-</li>
-<li>
-<t>
-Obtain a dedicated IPv6 address for each CLAT IPv4 address.
-</t>
-</li>
-<li>
-<t>
-Obtain a dedicated /64 prefix via DHCPv6-PD.
-</t>
-</li>
-</ul>
 </li>
 </ul>
 
 <t>
-In a single-address model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+If the CLAT instance doesn't obtain a dedicated IPv6 prefix, the instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is needed to differentiate between inbound native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example:
 </t>
@@ -565,7 +529,7 @@ The IPv4 header is 20 bytes long (or longer if IP options are present), while th
 This means that when CLAT translates an IPv4 packet to IPv6, it usually adds 20 bytes to the packet size.
 However, when CLAT translates a fragmented IPv4 packet, then Fragment Header needs to be added to the resulting IPv6 packet (Section 4.1 of <xref target="RFC7915"/>).
 The length of IPv6 Fragment Extension header is 8 bytes (Section 4.5 of <xref target="RFC8200"/>).
-Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-address mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
+Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
 </t>
 </section>
 

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -238,7 +238,7 @@ A CLAT instance provides an IPv4 address and the default IPv4 route to the local
 However, the node can also extend the network downstream and provides IPv4 network connectivity to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
 In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses. 
-The CLAT instance can either translate all other addresses statelessly to a dedicated prefix, or perform a stateful NAT44 between those addresses and a dedicated CLAT IPv4 address, which is stateless translated to a single dedicated IPv4 address.
+The CLAT instance can either translate these IPv4 addresses statelessly to IPv6 using a dedicated IPv6 prefix, or perform a stateful NAT44 between these IPv4 addresses and a dedicated CLAT IPv4 address, which is then statelessly translated to a single dedicated IPv6 address.
 </t>
 <t>
 This section only applies to that single dedicated IPv4 address, which CLAT instance uses for providing network connectivity to local appications and (in case of extending network connectivity downstream) for stateful NAT44.

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -264,7 +264,7 @@ When <xref target="RFC6877"/> was published, this deployment scenario was limite
 </li>
 </ul>
 <t>
-In the single-address model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="v6addr"/>).
+In the single-address model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
 The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
 If the node runs multiple CLAT instances in the single-address model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
 This approach limits the number of CLAT instances per node to 8, which seems to be more that sufficient at the time of writing. 
@@ -290,6 +290,8 @@ Therefore, as long as the host is not using DS-Lite, it MAY use 192.0.0.0/29 for
 <name>
 CLAT IPv6 Addresses
 </name>
+<section anchor="slaac">
+<name>Obtaining CLAT IPv6 Addresses</name>
 <t>
 Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, especially in environments like enterprise networks, Wi-Fi hotspots, etc. 
@@ -333,7 +335,7 @@ Obtain a dedicated /64 prefix via DHCPv6-PD.
 </ul>
 
 <t>
-In a single-address model, the CLAT instance SHOULD obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+In a single-address model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is needed to differentiate between inbound native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example:
 </t>
@@ -351,7 +353,35 @@ An ICMPv6 error packet from a global IPv6 address (not belonging to the NAT64 pr
 </ul>
 <t>
 Using a dedicated IPv6 source address for CLAT traffic allows the node to make that distinction without keeping state, so CLAT can operate in the stateless mode (see Section 1.3 of <xref target="RFC7915"/>.
+In the absence of a dedicated address the CLAT instance would be required to use stateful NAT64.
+At the same time [RFC6877] defines 464XLAT as an architecure where the customer-side translation is stateless (it is even mentioned explictly in the [RFC6877] title.
+While it is possible to implement stateful client-side trabslation and use a single IPv6 address for both native and translated IPv6 packets, that approach doesn't fit the framework defined in [RFC6877] and, therefore, is out of scope of this document.
 </t>
+<t>
+If the dedicated CLAT address is obtained via Stateless Address Autoconfiguration (SLAAC, <xref target="RFC4862"/>), the CLAT instance SHOULD ensure that the address is checksum-neutral. This means the CLAT IPv6 address has the same complement checksum as the local IPv4 CLAT address. See section 4.1 of <xref target="RFC6052"/>. 
+This means that the local IPv4 address needs to be assigned/known before the IPv6 address is configured).
+Using a checksum-neutral CLAT address provides the following benefits:
+</t>
+<ul>
+<li>
+<t>Better performance as CLAT doesn't need to recalculate the checksum.</t>
+</li>
+<li>
+<t>
+If a protocol uses the standard IP checksum, CLAT doesn't need to recalculate the checksum.
+That improves the chances of the protocol working via CLAT even if CLAT is not aware of the protocol's semantics.
+</t>
+</li>
+</ul>
+
+<t>
+To protect user privacy and prevent user tracking through CLAT addresses, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks, even if the NAT64 prefix and the local IPv4 CLAT address do not change. 
+In particular, the node SHOULD generate a random CLAT address every time the network attachement changes to another network.
+</t>
+</section>
+
+<section>
+<name>CLAT vs non-CLAT IPv6 Addresses Behaviour</name>
 <t>
 Reports from the field indicate that some CLAT implementations exhibit different behavior for their CLAT IPv6 addresses compared to native IPv6 addresses.
 While this approach may simplify implementation, it often leads to a degraded user experience, as described below:
@@ -404,28 +434,7 @@ Justification: not registering CLAT addresses reduces traffic visibility for net
 </ul>
 </li>
 </ul>
-<t>
-If the dedicated CLAT address is obtained via Stateless Address Autoconfiguration (SLAAC, <xref target="RFC4862"/>), the CLAT instance SHOULD ensure that the address is checksum-neutral. This means the CLAT IPv6 address has the same complement checksum as the local IPv4 CLAT address. See section 4.1 of <xref target="RFC6052"/>. 
-This means that the local IPv4 address needs to be assigned/known before the IPv6 address is configured).
-Using a checksum-neutral CLAT address provides the following benefits:
-</t>
-<ul>
-<li>
-<t>Better performance as CLAT doesn't need to recalculate the checksum.</t>
-</li>
-<li>
-<t>
-If a protocol uses the standard IP checksum, CLAT doesn't need to recalculate the checksum.
-That improves the chances of the protocol working via CLAT even if CLAT is not aware of the protocol's semantics.
-</t>
-</li>
-</ul>
-
-<t>
-To protect user privacy and prevent user tracking through CLAT addresses, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks, even if the NAT64 prefix and the local IPv4 CLAT address do not change. 
-In particular, the node SHOULD generate a random CLAT address every time the network attachement changes to another network.
-</t>
-
+</section>
 </section>
 </section>
 
@@ -741,7 +750,7 @@ However, as of the time of this document's publication, it's much more likely th
       <name>Privacy Considerations</name>
       <t>
 This document does not introduce any new privacy considerations, but there are some existing privacy considerations not documented in <xref target="RFC6877"/>. 
-In particular, if the instance utilizes the same CLAT IPv6 address for an extensive period of time or, much worse, uses the same CLAT address when connecting to different networks, eavesdroppers and information collectors could potentially correlate various network activity to the same node. To mitigate that risk and make address-based network-activity correlation more difficult, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks (see <xref target="v6addr"/>).
+In particular, if the instance utilizes the same CLAT IPv6 address for an extensive period of time or, much worse, uses the same CLAT address when connecting to different networks, eavesdroppers and information collectors could potentially correlate various network activity to the same node. To mitigate that risk and make address-based network-activity correlation more difficult, the node SHOULD generate a different interface id for the CLAT address when connecting to different networks (see <xref target="slaac"/>).
 </t>
 <t>
 It should be noted that the node's CLAT IPv6 address is only used (and visible to observers) when the traffic is carried from the CLAT node to the PLAT device.

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -137,6 +137,11 @@ CLAT Node: a node (a host or a router) which performs CLAT functions by running 
 </li>
 <li>
 <t>
+Dedicated prefix model: a scenario when the node performing CLAT functions also extends the IPv4 network connectivity downstream, to other connected systems. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireline network architecture", this scenario is also applicable for wireless or 3GPP routers. Therefore the term "wireline" is no longer accurate and not used in this document.
+</t>
+</li>
+<li>
+<t>
 IPv4-only application: An application which requires the presence of an IPv4 address and/or IPv4 default route to operate. Examples include but are not limited to applications using IPv4 literals or opening IPv4-only sockets. 
 </t>
 </li>
@@ -152,12 +157,7 @@ Native IPv4 (such as in 'native IPv4 connectivity' or 'native IPv4 default gatew
 </li>
 <li>
 <t>
-Shared connectivity model: a scenario when the node performing CLAT functions also extends the IPv4 network connectivity downstream, to other connected systems. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireline network architecture", this scenario is also applicable for wireless or 3GPP routers. Therefore the term "wireline" is no longer accurate and not used in this document.
-</t>
-</li>
-<li>
-<t>
-Single-device model: a scenario when the node performing CLAT functions provides an IPv4 address and the default route to the local node's network stack only. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireless network architecture", this scenario is applicable for wired networks as well (e.g. desktops or servers using wired connections). Therefore the term "wireless" is no longer accurate and not used in this document.
+Single-address model: a scenario when the node performing CLAT functions provides an IPv4 address and the default route to the local node's network stack only. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireless network architecture", this scenario is applicable for wired networks as well (e.g. desktops or servers using wired connections). Therefore the term "wireless" is no longer accurate and not used in this document.
 </t>
 </li>
 <li>
@@ -249,7 +249,7 @@ There are two different 464XLAT deployments models:
 <ul>
 <li>
 <t>
-A shared connectivity model (<xref target="RFC6877"/> uses the term "wireline network architecture").
+A dedicated prefix model (<xref target="RFC6877"/> uses the term "wireline network architecture").
 In that case, the node performing CLAT functions also extends the network downstream and provides network connectivity services to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
 In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses.
@@ -257,41 +257,24 @@ In all those cases, systems behind the CLAT node usually use <xref target="RFC19
 </li>
 <li>
 <t>
-A single-device model (<xref target="RFC6877"/> uses the term "wireless network architecture").
+A single-address model (<xref target="RFC6877"/> uses the term "wireless network architecture").
 In that case, the CLAT instance provides an IPv4 address and the default route to the local node's network stack only.
 When <xref target="RFC6877"/> was published, this deployment scenario was limited to 3GPP cases. Today, it is also deployed in other types of networks, such as enterprise networks and Wi-Fi hotspots, where hosts (as mobile phones, laptops and desktops) use CLAT to provide connectivity to IPv4-only local applications.
 </t>
 </li>
 </ul>
 <t>
-It should be noted that a device can operate in either a single-device mode or a shared connectivity mode, depending on its configuration.
-For example:
-</t>
-<ul>
-<li>
-<t>
-A mobile phone connected to an IPv6-only mobile network operates in single-device mode when tethering is disabled, but transitions to shared connectivity mode when tethering is enabled.
-</t>
-</li>
-<li>
-<t>
-An IPv6-only laptop enabling virtualization (creating a virtual network inside the operating system) changes its CLAT from a single-device to a shared connectivity model.
-</t>
-</li>
-</ul>
-
-<t>
-In the single-device model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
+In the single-address model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
 The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
-If the node runs multiple CLAT instances in the single-device model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
+If the node runs multiple CLAT instances in the single-address model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
 This approach limits the number of CLAT instances per node to 8, which seems to be more that sufficient at the time of writing. 
 If in the future some deployment scenarios require more that 8 CLAT instances per node, a new larger IPv4 range will be requested from IANA.
 </t>
 <t>
-The CLAT instance operating in a single-device model MUST NOT send packets on wire from the local CLAT addresses.
+The node MUST NOT send packets on wire from the local CLAT addresses.
 </t>
 <t>
-The host SHOULD use 255.255.255.255 as a netmask for the CLAT address from 192.0.0.0/29 netblock.
+The host SHOULD use 255.255.255.255 as a netmask for the CLAT address.
 That allows all 8 addresses from 192.0.0.0/29 to be used, if needed, since this means that each address is treated as being its own subnet, rather than being part of a subnet delineated by the prefix.
 </t>
 <t>
@@ -313,23 +296,23 @@ CLAT IPv6 Addresses
 Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, especially in environments like enterprise networks, Wi-Fi hotspots, etc. 
 Quite often the CLAT instance uses a single IPv6 address as a source for all IPv4 traffic translated by CLAT. 
-In particular, in a single device model (see <xref target="v4addr"/>) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
+In particular, in a single address model (see <xref target="v4addr"/>) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
 For instance, a home network that gets a /60 from its ISP can only connect up to 15 CLAT-enabled devices before it runs out of available prefixes.
-Even in a shared connectivity model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
+Even in a dedicated prefix model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
 </t>
 <t>
-This document updates <xref target="RFC6877"/> by removing the mandatory requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
+This document updates <xref target="RFC6877"/> by removing the requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
 The following recommendations are made instead:
 </t>
 <ul>
 <li>
 <t>
-In a single device model, the CLAT instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
+In a single-address model, the CLAT instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
 </t>
 </li>
 <li>
 <t>
-In a shared connectivity model, the CLAT instance MAY do one of the following:
+In a dedicated prefix model, the CLAT instance MAY do one of the following:
 </t>
 <ul>
 <li>
@@ -344,7 +327,7 @@ Obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </li>
 <li>
 <t>
-Obtain a dedicated /64 prefix via DHCPv6-PD and use that prefix for stateless translation.
+Obtain a dedicated /64 prefix via DHCPv6-PD.
 </t>
 </li>
 </ul>
@@ -352,7 +335,7 @@ Obtain a dedicated /64 prefix via DHCPv6-PD and use that prefix for stateless tr
 </ul>
 
 <t>
-In a single-device model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+In a single-address model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is needed to differentiate between inbound native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example:
 </t>
@@ -582,7 +565,7 @@ The IPv4 header is 20 bytes long (or longer if IP options are present), while th
 This means that when CLAT translates an IPv4 packet to IPv6, it usually adds 20 bytes to the packet size.
 However, when CLAT translates a fragmented IPv4 packet, then Fragment Header needs to be added to the resulting IPv6 packet (Section 4.1 of <xref target="RFC7915"/>).
 The length of IPv6 Fragment Extension header is 8 bytes (Section 4.5 of <xref target="RFC8200"/>).
-Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-device mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
+Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-address mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
 </t>
 </section>
 

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -137,11 +137,6 @@ CLAT Node: a node (a host or a router) which performs CLAT functions by running 
 </li>
 <li>
 <t>
-Dedicated prefix model: a scenario when the node performing CLAT functions also extends the IPv4 network connectivity downstream, to other connected systems. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireline network architecture", this scenario is also applicable for wireless or 3GPP routers. Therefore the term "wireline" is no longer accurate and not used in this document.
-</t>
-</li>
-<li>
-<t>
 IPv4-only application: An application which requires the presence of an IPv4 address and/or IPv4 default route to operate. Examples include but are not limited to applications using IPv4 literals or opening IPv4-only sockets. 
 </t>
 </li>
@@ -157,7 +152,12 @@ Native IPv4 (such as in 'native IPv4 connectivity' or 'native IPv4 default gatew
 </li>
 <li>
 <t>
-Single-address model: a scenario when the node performing CLAT functions provides an IPv4 address and the default route to the local node's network stack only. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireless network architecture", this scenario is applicable for wired networks as well (e.g. desktops or servers using wired connections). Therefore the term "wireless" is no longer accurate and not used in this document.
+Shared connectivity model: a scenario when the node performing CLAT functions also extends the IPv4 network connectivity downstream, to other connected systems. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireline network architecture", this scenario is also applicable for wireless or 3GPP routers. Therefore the term "wireline" is no longer accurate and not used in this document.
+</t>
+</li>
+<li>
+<t>
+Single-device model: a scenario when the node performing CLAT functions provides an IPv4 address and the default route to the local node's network stack only. See <xref target="v4addr"/>. While <xref target="RFC6877"/> uses the term "wireless network architecture", this scenario is applicable for wired networks as well (e.g. desktops or servers using wired connections). Therefore the term "wireless" is no longer accurate and not used in this document.
 </t>
 </li>
 <li>
@@ -249,7 +249,7 @@ There are two different 464XLAT deployments models:
 <ul>
 <li>
 <t>
-A dedicated prefix model (<xref target="RFC6877"/> uses the term "wireline network architecture").
+A shared connectivity model (<xref target="RFC6877"/> uses the term "wireline network architecture").
 In that case, the node performing CLAT functions also extends the network downstream and provides network connectivity services to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
 In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses.
@@ -257,24 +257,41 @@ In all those cases, systems behind the CLAT node usually use <xref target="RFC19
 </li>
 <li>
 <t>
-A single-address model (<xref target="RFC6877"/> uses the term "wireless network architecture").
+A single-device model (<xref target="RFC6877"/> uses the term "wireless network architecture").
 In that case, the CLAT instance provides an IPv4 address and the default route to the local node's network stack only.
 When <xref target="RFC6877"/> was published, this deployment scenario was limited to 3GPP cases. Today, it is also deployed in other types of networks, such as enterprise networks and Wi-Fi hotspots, where hosts (as mobile phones, laptops and desktops) use CLAT to provide connectivity to IPv4-only local applications.
 </t>
 </li>
 </ul>
 <t>
-In the single-address model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
+It should be noted that a device can operate in either a single-device mode or a shared connectivity mode, depending on its configuration.
+For example:
+</t>
+<ul>
+<li>
+<t>
+A mobile phone connected to an IPv6-only mobile network operates in single-device mode when tethering is disabled, but transitions to shared connectivity mode when tethering is enabled.
+</t>
+</li>
+<li>
+<t>
+An IPv6-only laptop enabling virtualization (creating a virtual network inside the operating system) changes its CLAT from a single-device to a shared connectivity model.
+</t>
+</li>
+</ul>
+
+<t>
+In the single-device model, the CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).
 The node providing CLAT functions to local applications SHOULD use IPv4 addresses from the dedicated 192.0.0.0/29 range (<xref target="RFC7335"/>), reserved for IPv4 continuity solutions including but not limited to 464XLAT.
-If the node runs multiple CLAT instances in the single-address model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
+If the node runs multiple CLAT instances in the single-device model (see <xref target="multihomed"/>), the node SHOULD use different local IPv4 addresses for each CLAT instance.
 This approach limits the number of CLAT instances per node to 8, which seems to be more that sufficient at the time of writing. 
 If in the future some deployment scenarios require more that 8 CLAT instances per node, a new larger IPv4 range will be requested from IANA.
 </t>
 <t>
-The node MUST NOT send packets on wire from the local CLAT addresses.
+The CLAT instance operating in a single-device model MUST NOT send packets on wire from the local CLAT addresses.
 </t>
 <t>
-The host SHOULD use 255.255.255.255 as a netmask for the CLAT address.
+The host SHOULD use 255.255.255.255 as a netmask for the CLAT address from 192.0.0.0/29 netblock.
 That allows all 8 addresses from 192.0.0.0/29 to be used, if needed, since this means that each address is treated as being its own subnet, rather than being part of a subnet delineated by the prefix.
 </t>
 <t>
@@ -296,23 +313,23 @@ CLAT IPv6 Addresses
 Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, especially in environments like enterprise networks, Wi-Fi hotspots, etc. 
 Quite often the CLAT instance uses a single IPv6 address as a source for all IPv4 traffic translated by CLAT. 
-In particular, in a single address model (see <xref target="v4addr"/>) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
+In particular, in a single device model (see <xref target="v4addr"/>) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
 For instance, a home network that gets a /60 from its ISP can only connect up to 15 CLAT-enabled devices before it runs out of available prefixes.
-Even in a dedicated prefix model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
+Even in a shared connectivity model, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses from the dedicated prefix to a single IPv4 address, and then perform stateless CLAT. 
 </t>
 <t>
-This document updates <xref target="RFC6877"/> by removing the requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
+This document updates <xref target="RFC6877"/> by removing the mandatory requirement to acquire a dedicated /64 prefix for the purpose of sending and receiving statelessly translated packets.
 The following recommendations are made instead:
 </t>
 <ul>
 <li>
 <t>
-In a single-address model, the CLAT instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
+In a single device model, the CLAT instance SHOULD NOT obtain a dedicated /64 for the purpose of sending and receiving statelessly translated packets.
 </t>
 </li>
 <li>
 <t>
-In a dedicated prefix model, the CLAT instance MAY do one of the following:
+In a shared connectivity model, the CLAT instance MAY do one of the following:
 </t>
 <ul>
 <li>
@@ -327,7 +344,7 @@ Obtain a dedicated IPv6 address for each CLAT IPv4 address.
 </li>
 <li>
 <t>
-Obtain a dedicated /64 prefix via DHCPv6-PD.
+Obtain a dedicated /64 prefix via DHCPv6-PD and use that prefix for stateless translation.
 </t>
 </li>
 </ul>
@@ -335,7 +352,7 @@ Obtain a dedicated /64 prefix via DHCPv6-PD.
 </ul>
 
 <t>
-In a single-address model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
+In a single-device model, the CLAT instance MUST obtain a dedicated IPv6 address used exclusively for CLAT functions. 
 This is needed to differentiate between inbound native IPv6 traffic and traffic which needs to be passed to the CLAT instance.
 For example:
 </t>
@@ -565,7 +582,7 @@ The IPv4 header is 20 bytes long (or longer if IP options are present), while th
 This means that when CLAT translates an IPv4 packet to IPv6, it usually adds 20 bytes to the packet size.
 However, when CLAT translates a fragmented IPv4 packet, then Fragment Header needs to be added to the resulting IPv6 packet (Section 4.1 of <xref target="RFC7915"/>).
 The length of IPv6 Fragment Extension header is 8 bytes (Section 4.5 of <xref target="RFC8200"/>).
-Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-address mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
+Therefore, to minimize undesirable IP fragmentation (<xref target="RFC8900"/>), the CLAT instance in a single-device mode SHOULD present IPv4-only applications with an IPv4 MTU which is 28 bytes smaller than the IPv6 MTU of the interface the instance is running on.
 </t>
 </section>
 

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -237,7 +237,7 @@ CLAT IPv4 Addresses
 A CLAT instance provides an IPv4 address and the default IPv4 route to the local node's network stack.
 However, the node can also extend the network downstream and provides IPv4 network connectivity to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
- In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses. 
+In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses. 
 The CLAT instance can either translate all other addresses statelessly to a dedicated prefix, or perform a stateful NAT44 between those addresses and a dedicated CLAT IPv4 address, which is stateless translated to a single dedicated IPv4 address.
 </t>
 <t>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -241,7 +241,7 @@ In all those cases, systems behind the CLAT node usually use <xref target="RFC19
 The CLAT instance can either translate these IPv4 addresses statelessly to IPv6 using a dedicated IPv6 prefix, or perform a stateful NAT44 between these IPv4 addresses and a dedicated CLAT IPv4 address, which is then statelessly translated to a single dedicated IPv6 address.
 </t>
 <t>
-This section only applies to that single dedicated IPv4 address, which CLAT instance uses for providing network connectivity to local appications and (in case of extending network connectivity downstream) for stateful NAT44.
+This section only applies to a single dedicated IPv4 address which the CLAT instance uses for providing network connectivity only to local applications or using stateful NAT44 when extending network connectivity downstream.
 </t>
 <t>
 The CLAT instance needs a single IPv4 CLAT address and a single CLAT-only IPv6 address (which is distinct from the one or more IPv6 addresses used by the node running CLAT for its own native IPv6 connectivity, see <xref target="slaac"/>).

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -287,8 +287,8 @@ The following recommendations are made instead:
 <ul>
 <li>
 <t>
-If the node is extending IPv4 connectivity downstream and is not performing stateful NAT44 (so it needs to translate downstream IPv4 addresses to IPv6 statelessly), the node 
-SHOULD obtain a dedicated /64 prefix (e.g. via DHCPv6-PD).
+If the node is extending IPv4 connectivity downstream, the node 
+SHOULD obtain a dedicated /64 prefix (e.g. via DHCPv6-PD) for stateless translation of downstream IPv4 addresses unless it chooses to perform stateful NAT44 from the downstream IPv4 addresses to a single IPv4 address for stateless translation.
 </t>
 </li>
 <li>

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -234,8 +234,8 @@ CLAT Addresses Considerations
 CLAT IPv4 Addresses
 </name>
 <t>
-A CLAT instance provides an IPv4 address and the default route to the local node's network stack.
-However, the node can also extend the network downstream and provides network connectivity services to other connected systems.
+A CLAT instance provides an IPv4 address and the default IPv4 route to the local node's network stack.
+However, the node can also extend the network downstream and provides IPv4 network connectivity to other connected systems.
 Those systems can be physical (e.g. various clients connected to a CPE router), or logical (e.g. virtual systems running on a node, while the host system acts as a router and performs CLAT). 
  In all those cases, systems behind the CLAT node usually use <xref target="RFC1918"/> addresses. 
 The CLAT instance can either translate all other addresses statelessly to a dedicated prefix, or perform a stateful NAT44 between those addresses and a dedicated CLAT IPv4 address, which is stateless translated to a single dedicated IPv4 address.

--- a/draft-ietf-v6ops-464xlaton.xml
+++ b/draft-ietf-v6ops-464xlaton.xml
@@ -276,7 +276,7 @@ CLAT IPv6 Addresses
 Section 6.3 of <xref target="RFC6877"/> recommends that the CLAT instance acquires a dedicated /64 for translating between IPv4 and IPv6, and only uses a single interface IPv6 address if a dedicated prefix is not available via DHCPv6-PD.
 However, deployments where each node can obtain a dedicated /64 just for CLAT are rather uncommon, especially in environments like enterprise networks, Wi-Fi hotspots, etc. 
 Quite often the CLAT instance uses a single IPv6 address as a source for all IPv4 traffic translated by CLAT. 
-In particular, if the CLAT only provides the IPv4 connectivity to applications local to the node (or if the node can perform stateful NAT44) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
+In particular, if the CLAT only provides the IPv4 connectivity to applications local to the node (or if the node chooses to perform stateful NAT44) the CLAT instance only need a single CLAT IPv6 address, so obtaining a /64 is wasteful.
 For instance, a home network that gets a /60 from its ISP can only connect up to 15 CLAT-enabled devices before it runs out of available prefixes.
 Even if the node extends IPv4 connectivity downstream, the CLAT instance can first perform stateful NAT44 to translate all IPv4 addresses used by downstream devices to a single IPv4 address, and then perform stateless CLAT. 
 </t>


### PR DESCRIPTION
- Contains the same change as https://github.com/furry13/v6ops-464xlat-enable/pull/57/commits/ab367b7caa503f6a8e534579d53006a63fdd391f (s/SHOULD/MUST/ for a dedicated IPv6 address)
- Instead of renaming the models, remove that classification and describe the behaviour explicitly